### PR TITLE
Spritesmith version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-spritely",
   "description": "Grunt library for generating sprites sheets.  Forked from grunt-spritesmith and caters to Grunt 0.4.",
-  "version": "0.4.4",
+  "version": "0.4.3",
   "homepage": "https://github.com/chrisdanford/grunt-spritely",
   "author": {
     "name": "Chris Danford",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-spritely",
   "description": "Grunt library for generating sprites sheets.  Forked from grunt-spritesmith and caters to Grunt 0.4.",
-  "version": "0.4.2",
+  "version": "0.4.4",
   "homepage": "https://github.com/chrisdanford/grunt-spritely",
   "author": {
     "name": "Chris Danford",
@@ -60,7 +60,7 @@
     "test": "cd src-test && grunt"
   },
   "dependencies": {
-    "spritesmith": "~0.13.0",
+    "spritesmith": "1.4.6",
     "json2css": "~4.1.0",
     "underscore": "~1.4.2",
     "url2": "*",

--- a/src/grunt-spritesmith.js
+++ b/src/grunt-spritesmith.js
@@ -66,7 +66,7 @@ module.exports = function (grunt) {
       cssTemplate = data.cssTemplate,
       that = this;
 
-    // Verify all properties are here 
+    // Verify all properties are here
     if (this.files.length === 0) {
       return grunt.fatal("grunt.sprite requires files.");
     }
@@ -98,7 +98,7 @@ module.exports = function (grunt) {
       // Run through spritesmith
       var spritesmithParams = {
         'src': file.src,
-        'engine': data.engine || 'auto',
+        'engine': data.engine,
         'algorithm': data.algorithm || 'top-down',
         'padding': data.padding || 0,
         'engineOpts': data.engineOpts || {},


### PR DESCRIPTION
Updated spritesmith version to support newer node versions. Changed `engine` parameter to spritesmith as `auto` no longer works. Bumped version number for npm.
